### PR TITLE
Allow using Yao 0.2+

### DIFF
--- a/kaname.gemspec
+++ b/kaname.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "yao", "~> 0.1.0"
+  spec.add_dependency "yao", ">= 0.2.13"
   spec.add_dependency "diffy"
   spec.add_dependency "hashdiff"
   spec.add_dependency "thor"


### PR DESCRIPTION
Since Kaname has a conflicting dependency constraint on Yao with the latest version of Kakine, we cannot install both of them in a single Gemfile.

This patch allows use of yao 0.2 (and actually drops support for old Yao 0.1).

@hsbt 
