### PR TITLE
Fix undefined class var error

### DIFF
--- a/lib/kaname/config.rb
+++ b/lib/kaname/config.rb
@@ -3,6 +3,10 @@ require 'yaml'
 
 module Kaname
   class Config
+    %w[username management_url].each do |m|
+      self.class_variable_set(:"@@#{m}", String.new)
+    end
+
     def self.setup
       load_config
       setup_yao


### PR DESCRIPTION
Invoking `kaname password` command fails:

```
/Users/antipop/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/kaname-0.6.1/lib/kaname/config.rb:12:in `username': uninitialized class variable @@username in Kaname::Config (NameError)
```

It's because class variables are touched without initializing by `Kaname::Config.setup`. Incidentally, class variables must be always initialized when shown in code. So I fix it as this PR.