### PR TITLE
Use yao client in kaname password

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ auth_url: "http://your-openstack-auth-endpoint/v2.0"
 username: "admin"
 tenant: "admin"
 password: "admin-no-password"
-management_url: "http://your-openstack-management-endpoint/v2.0"
 ```
 
 also, you can set some options.

--- a/lib/kaname/config.rb
+++ b/lib/kaname/config.rb
@@ -3,9 +3,7 @@ require 'yaml'
 
 module Kaname
   class Config
-    %w[username management_url].each do |m|
-      self.class_variable_set(:"@@#{m}", String.new)
-    end
+    @@username = String.new
 
     def self.setup
       load_config
@@ -14,10 +12,6 @@ module Kaname
 
     def self.username
       @@username
-    end
-
-    def self.management_url
-      @@management_url
     end
 
     private
@@ -36,7 +30,6 @@ module Kaname
       @@tenant         = config['tenant']
       @@username       = config['username']
       @@password       = config['password']
-      @@management_url = config['management_url']
       @@client_cert    = config['client_cert']
       @@client_key     = config['client_key']
       @@region_name    = config['region_name']

--- a/lib/kaname/resource.rb
+++ b/lib/kaname/resource.rb
@@ -4,7 +4,7 @@ module Kaname
   class Resource
     class << self
       def yaml(filename = 'keystone.yml')
-        if File.exists?(filename)
+        if File.exist?(filename)
           @_yaml ||= expand_all_tenants(YAML.load_file(filename))
         end
       end

--- a/test/test_kaname_adapter_real.rb
+++ b/test/test_kaname_adapter_real.rb
@@ -4,27 +4,27 @@ class TestKanameAdapterReal < Minitest::Test
   def test_update_user_password
     Kaname::Config.stubs(:setup)
 
-    mock_auth = MiniTest::Mock.new.expect(:token, 'dummy_token')
     mock_user = MiniTest::Mock.new.expect(:id, 'dummy_id')
 
     dummy_management_url = "http://www.example.com:5000/v2.0"
 
-    stub_request(:patch, "#{dummy_management_url}/OS-KSCRUD/users/dummy_id").
-      with(:body => "{\"user\":{\"password\":\"new\",\"original_password\":\"old\"}}",
-           :headers => {'Content-Type'=>'application/json', 'X-Auth-Token'=>"dummy_token"}).
-      to_return(:status => 200)
+    Yao::Client.reset_client(dummy_management_url)
+    Yao.default_client.register_endpoints({"identity" => {public_url: dummy_management_url}})
 
-    Yao::Auth.stub(:try_new, mock_auth) do
-      Yao::User.stub(:get_by_name, mock_user) do
-        Kaname::Config.stub(:management_url, dummy_management_url) do
-          Kaname::Config.stub(:username, "dummy_username") do
-            Kaname::Adapter::ReadAndWrite.new.update_user_password('old', 'new')
-          end
-        end
+    stub_request(:patch, "http://www.example.com:5000/v2.0/OS-KSCRUD/users/dummy_id").
+      with(body: "{\"user\":{\"password\":\"new\",\"original_password\":\"old\"}}",
+           headers: {'Accept'=>'application/json',
+                     'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                     'Content-Type'=>'application/json',
+                     'User-Agent'=>'Faraday v0.12.2'}).
+    to_return(status: 200, body: "", headers: {})
+
+    Yao::User.stub(:get_by_name, mock_user) do
+      Kaname::Config.stub(:username, "dummy_username") do
+        Kaname::Adapter::ReadAndWrite.new.update_user_password('old', 'new')
       end
     end
 
-    mock_auth.verify
     mock_user.verify
   end
 end


### PR DESCRIPTION
`kaname password` では、Net::HTTPを使ってリクエストしていましたが、Yaoのクライアントに置き換えます。
これにより、クライアント証明書対応等Yaoがサポートしているリクエスト方式を利用できます。