### PR TITLE
APIのクライアント証明書認証はオプショナル

### DIFF
--- a/lib/kaname/config.rb
+++ b/lib/kaname/config.rb
@@ -4,6 +4,8 @@ require 'yaml'
 module Kaname
   class Config
     @@username = String.new
+    @@client_key = nil
+    @@client_cert = nil
 
     def self.setup
       load_config unless envs_exist?


### PR DESCRIPTION
必須ではないので初期化しておくと良いかと思いました。