### PR TITLE
fix Hashdiff deprecation

### DIFF
--- a/kaname.gemspec
+++ b/kaname.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "yao", ">= 0.3.3"
   spec.add_dependency "diffy"
-  spec.add_dependency "hashdiff"
+  spec.add_dependency "hashdiff", ">= 1.0.0"
   spec.add_dependency "thor"
 
   spec.add_development_dependency "bundler"

--- a/lib/kaname/cli.rb
+++ b/lib/kaname/cli.rb
@@ -29,7 +29,7 @@ module Kaname
       end
 
       if Kaname::Resource.yaml
-        diffs = HashDiff.diff(adapter.users_hash, Kaname::Resource.yaml)
+        diffs = Hashdiff.diff(adapter.users_hash, Kaname::Resource.yaml)
         diffs.each do |diff|
           resource = diff[1].split('.')
           if resource.size == 1 # "user"


### PR DESCRIPTION
in 1.0, Hashdiff removes deprecation and shim. https://github.com/liufengyun/hashdiff/pull/70

so now we fix deprecation and specify a version requirement.