### PR TITLE
パスワードの文字列を指定できるオプションを追加する

### DIFF
--- a/lib/kaname/cli.rb
+++ b/lib/kaname/cli.rb
@@ -21,8 +21,11 @@ module Kaname
 
     option :dryrun, type: :boolean
     option :filename, aliases: :f, type: :string, default: 'keystone.yml'
+    option :password_length, aliases: :L, type: :numeric, default: 14
     desc 'apply', 'Commands about configuration apply'
     def apply
+      Generator.password_length = options[:password_length]
+
       adapter = if options[:dryrun]
         Kaname::Adapter::ReadOnly.new
       else

--- a/lib/kaname/generator.rb
+++ b/lib/kaname/generator.rb
@@ -3,8 +3,16 @@ require 'securerandom'
 module Kaname
   class Generator
     class << self
+      def password_length
+        @password_length ||= 14
+      end
+
+      def password_length=(length)
+        @password_length = length
+      end
+
       def password
-        SecureRandom.base64(6)
+        SecureRandom.base64(@password_length)
       end
     end
   end


### PR DESCRIPTION
アカウント作成時のパスワードが6文字固定だったが
パスワードポリシーなどでこれ以上の文字数が最低制限されていた場合にエラーになるため
オプションで変更できるようにし、かつ初期文字列を14文字に変更した。
