### PR TITLE
test: fix test code and relax User-Agent matching

### DIFF
--- a/test/test_kaname_adapter_real.rb
+++ b/test/test_kaname_adapter_real.rb
@@ -4,7 +4,7 @@ class TestKanameAdapterReal < Minitest::Test
   def test_update_user_password
     Kaname::Config.stubs(:setup)
 
-    mock_user = MiniTest::Mock.new.expect(:id, 'dummy_id')
+    mock_user = Minitest::Mock.new.expect(:id, 'dummy_id')
 
     dummy_management_url = "http://www.example.com:5000/v2.0"
 
@@ -16,7 +16,7 @@ class TestKanameAdapterReal < Minitest::Test
            headers: {'Accept'=>'application/json',
                      'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
                      'Content-Type'=>'application/json',
-                     'User-Agent'=>'Yao/0.13.4 Faraday/1.0.1'}).
+                     'User-Agent'=>/Yao\/.+ Faraday\/.+/}).
     to_return(status: 200, body: "", headers: {})
 
     Yao::User.stub(:get_by_name, mock_user) do


### PR DESCRIPTION
## Changes
- Fix `MiniTest` to `Minitest` in test code
- Relax User-Agent matching condition (from fixed value to regex pattern)

## Reason
- `MiniTest` is deprecated, `Minitest` is the correct notation
- User-Agent version changes frequently, so fixed value matching reduces test maintainability